### PR TITLE
Fix mulligan issue by firing game start event before initial card draw

### DIFF
--- a/Hearthstone-Deck-Tracker/LogReader/Hearthstone.m
+++ b/Hearthstone-Deck-Tracker/LogReader/Hearthstone.m
@@ -126,13 +126,16 @@
     _logObserver = [LogObserver new];
     _logAnalyzer = [LogAnalyzer new];
     
-    [_logAnalyzer setPlayerHero:^(Player player, NSString *heroId) {
+    [_logAnalyzer setGameDidStart:^(Player player) {
         if (player == PlayerMe) {
             NSLog(@"----- Game Started -----");
             for (NSObject<CardListDelegate>* list in ws.updateList) {
                 [list resetCards];
             }
         }
+    }];
+    
+    [_logAnalyzer setPlayerHero:^(Player player, NSString *heroId) {
         NSLog(@"Player %u picked %@", player, heroId);
     }];
     

--- a/Hearthstone-Deck-Tracker/LogReader/LogAnalyzer.h
+++ b/Hearthstone-Deck-Tracker/LogReader/LogAnalyzer.h
@@ -9,6 +9,11 @@
 #import <Foundation/Foundation.h>
 #import "Hearthstone.h"
 
+extern NSString *const CARD_ACTIONS_PATTERN;
+extern NSString *const GOT_COIN_PATTERN;
+extern NSString *const HERO_PATTERN;
+extern NSString *const GAME_START_PATTERN;
+
 @interface LogAnalyzer : NSObject
 
 - (void)analyzeLine:(NSString *)line;
@@ -19,6 +24,7 @@
 @property (nonatomic, copy) void(^playerDidPlayCard)(Player player, NSString *cardID);
 @property (nonatomic, copy) void(^playerDidReturnHandCard)(Player player, NSString *cardID);
 
+@property (nonatomic, copy) void(^gameDidStart)(Player player);
 @property (nonatomic, copy) void(^playerDidDie)(Player player);
 @property (nonatomic, copy) void(^playerGotCoin)(Player player);
 @property (nonatomic, copy) void(^playerHero)(Player player, NSString *heroId);


### PR DESCRIPTION
This is a fix for the current mulligan issue. Drawn cards appear to not be removed from the deck and the returned cards are erroneously incremented.

The issue was the log event being used to trigger the start of a game, and reset the deck list, was happening after the mulligan process started. The cards were being correctly removed from the deck in the mulligan stage but then immediately after the deck was being reset.

I have changed the log event used to trigger the start of a new match to `[Power] GameState.DebugPrintPower() - CREATE_GAME` which happens before the mulligan stage starts. The `_logAnalyzer setPlayerHero` method now only logs the hero selection. The newly created `_logAnalyzer setGameDidStart` contains the game start logic that was in `_logAnalyzer setPlayerHero`.
